### PR TITLE
New name space

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ XmlSqlASt can generate XML:
      numlines="6">
    <c:MULTI_LINE_COMMENT>/* simple table alias - self join
    from: https://www.oracletutorial.com/oracle-basics/oracle-alias/ */</c:MULTI_LINE_COMMENT>
-   <sql_script>
+   <script>
       <c:WS>\n</c:WS>
       <query_block rule-path="unit_statement data_manipulation_language_statements select_statement subquery subquery_basic_elements">
          <selector>
@@ -151,7 +151,7 @@ XmlSqlASt can generate XML:
          </from_clause>
       </query_block>
       <t:SEMICOLON>;</t:SEMICOLON>
-   </sql_script>
+   </script>
 </sql>
 ```
 Additional styling can be applied to generate JSON using included XSLT stylesheets:  
@@ -165,7 +165,7 @@ Additional styling can be applied to generate JSON using included XSLT styleshee
     [ 
       { "multi_line_comment" : "\/* simple table alias - self join\n   from: https:\/\/www.oracletutorial.com\/oracle-basics\/oracle-alias\/ *\/" },
       
-      { "sql_script" : 
+      { "script" : 
         [ 
           { "whitespace" : "\\n" },
           

--- a/build.xml
+++ b/build.xml
@@ -16,11 +16,9 @@
     <target name="all" depends="sqlxmlast-to-xml,xmlsqlast-shorten,xmlsqlast-json-structure,json-structure-to-json"/>
     <!-- convert misc formats to XML AST -->
     <target name="sqlxmlast-to-xml">
-        <!--
         <sqlxmlast grammar="oracle" extension=".xml" basedir="examples/plsql" destdir="target/sqlxmlast/plsql"/>
         <sqlxmlast grammar="sybase" extension=".xml" basedir="examples/tsql" destdir="target/sqlxmlast/tsql"/>
         <sqlxmlast grammar="antlr4" extension=".xml" basedir="examples/antlr4" destdir="target/sqlxmlast/antlr4"/>
-        -->
         <sqlxmlast grammar="java8" extension=".xml" basedir="examples/java8" destdir="target/sqlxmlast/java8"/>
     </target>
     <!-- make XML compacter form -->

--- a/examples/plsql/plsql_double_comment.sql
+++ b/examples/plsql/plsql_double_comment.sql
@@ -1,0 +1,14 @@
+-- comment
+/* simple plsql */
+/* insert/select case */
+INSERT
+/* this too */
+/* and this too */
+-- comment
+INTO   contacts (contact_id, last_name, first_name)
+-- comment
+/* and this too */
+SELECT customer_id, last_name, first_name
+FROM   customers
+WHERE  customer_id = '123';
+/* comment at the end */

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/ANTLRv4Lexer.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/ANTLRv4Lexer.g4
@@ -47,20 +47,20 @@ options { superClass = LexerAdaptor; }
 
 // Standard set of fragments
 tokens { TOKEN_REF , RULE_REF , LEXER_CHAR_SET }
-channels { OFF_CHANNEL , COMMENT }
+// channels { OFF_CHANNEL , COMMENT }
 
 // -------------------------
 // Comments
 DOC_COMMENT
-   : DocComment -> channel (COMMENT)
+   : DocComment -> channel (HIDDEN)
    ;
 
-BLOCK_COMMENT
-   : BlockComment -> channel (COMMENT)
+MULTI_LINE_COMMENT
+   : BlockComment -> channel (HIDDEN)
    ;
 
-LINE_COMMENT
-   : LineComment -> channel (COMMENT)
+SINGLE_LINE_COMMENT
+   : LineComment -> channel (HIDDEN)
    ;
 
 // -------------------------
@@ -273,9 +273,13 @@ ID
    // -------------------------
    // Whitespace
 
+/*
 WS
    : Ws+ -> channel (OFF_CHANNEL)
    ;
+*/
+
+SPACES: Ws+ -> channel(HIDDEN);
 
 // -------------------------
 // Illegal Characters

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/ANTLRv4Parser.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/ANTLRv4Parser.g4
@@ -42,8 +42,9 @@ parser grammar ANTLRv4Parser;
 
 options { tokenVocab = ANTLRv4Lexer; }
 // The main entry point for parsing a v4 grammar.
-sql_script
-    : grammarSpec? EOF
+script
+    : grammarSpec EOF
+    | EOF
     ;
 
 grammarSpec

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/Java8Lexer.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/Java8Lexer.g4
@@ -1114,13 +1114,13 @@ ELLIPSIS : '...';
 // Whitespace and comments
 //
 
-WS  :  [ \t\r\n\u000C]+ -> skip
+SPACES  :  [ \t\r\n\u000C]+ -> channel(HIDDEN)
     ;
 
-COMMENT
-    :   '/*' .*? '*/' -> skip
+MULTI_LINE_COMMENT
+    :   '/*' .*? '*/' -> channel(HIDDEN)
     ;
 
-LINE_COMMENT
-    :   '//' ~[\r\n]* -> skip
+SINGLE_LINE_COMMENT
+    :   '//' ~[\r\n]* -> channel(HIDDEN)
     ;

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/Java8Parser.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/Java8Parser.g4
@@ -59,7 +59,7 @@ options {
 /*
  * Productions from §3 (Lexical Structure)
  */
-sql_script
+script
     : compilationUnit? EOF
     ;
 
@@ -197,33 +197,25 @@ wildcardBounds
  */
 
 packageName
-	:	Identifier
-	|	packageName '.' Identifier
+	:	generalName
 	;
 
 typeName
-	:	Identifier
-	|	packageOrTypeName '.' Identifier
-	;
-
-packageOrTypeName
-	:	Identifier
-	|	packageOrTypeName '.' Identifier
+	:	generalName
 	;
 
 expressionName
-	:	Identifier
-	|	ambiguousName '.' Identifier
+	:	generalName
+	;
+
+generalName
+	:	Identifier ('.' Identifier)*
 	;
 
 methodName
 	:	Identifier
 	;
 
-ambiguousName
-	:	Identifier
-	|	ambiguousName '.' Identifier
-	;
 
 /*
  * Productions from §7 (Packages)
@@ -253,7 +245,7 @@ singleTypeImportDeclaration
 	;
 
 typeImportOnDemandDeclaration
-	:	'import' packageOrTypeName '.' '*' ';'
+	:	'import' generalName '.' '*' ';'
 	;
 
 singleStaticImportDeclaration

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/PlSqlLexer.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/PlSqlLexer.g4
@@ -2403,11 +2403,11 @@ FLOAT_FRAGMENT
 
 // Rule #097 <COMMENT>
 
-SINGLE_LINE_COMMENT: '--'  ~('\r' | '\n')* (NEWLINE | EOF)  -> channel(HIDDEN);
-MULTI_LINE_COMMENT:  '/*' .*? '*/' (SPACES)? EOF? -> channel(HIDDEN);
+SINGLE_LINE_COMMENT: '--'  ~('\r' | '\n')*  -> channel(HIDDEN);
+MULTI_LINE_COMMENT:  '/*' .*? '*/' -> channel(HIDDEN);
 
-REM_COMMENT:          REM SPACE ~('\r' | '\n')* (NEWLINE | EOF)   -> channel(HIDDEN);
-PROMPT_COMMENT:       PROMPT SPACE ~('\r' | '\n')* (NEWLINE | EOF)   -> channel(HIDDEN);
+REM_COMMENT:          REM SPACE ~('\r' | '\n')*  -> channel(HIDDEN);
+PROMPT_COMMENT:       PROMPT SPACE ~('\r' | '\n')*  -> channel(HIDDEN);
 
 START_CMD
     // TODO When using full word START there is a conflict with START WITH in sequences and CONNECT BY queries

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/PlSqlParser.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/PlSqlParser.g4
@@ -23,7 +23,7 @@ parser grammar PlSqlParser;
 
 options { tokenVocab=PlSqlLexer; }
 
-sql_script // toplevel name
+script // toplevel name
     : ((unit_statement | sql_plus_command) SEMICOLON?)* EOF
     ;
 

--- a/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/TSqlParser.g4
+++ b/src/main/antlr4/nl/xs4all/home/ei/parsers/antlr/TSqlParser.g4
@@ -33,7 +33,7 @@ parser grammar TSqlParser;
 options { tokenVocab=TSqlLexer; }
 
 
-sql_script // toplevel name
+script // toplevel name
     : batch* EOF
     ;
 

--- a/src/main/java/nl/xs4all/home/ei/parsers/antlr/XmlAstWriter.java
+++ b/src/main/java/nl/xs4all/home/ei/parsers/antlr/XmlAstWriter.java
@@ -15,9 +15,9 @@ import java.util.*;
 
 public class XmlAstWriter {
 
-    private String commentNS = "urn:language:sql:comment";
-    private String grammarNS = "urn:language:sql:grammar";
-    private String tokenNS = "urn:language:sql:token";
+    private String commentNS = "urn:xmlast:comment";
+    private String grammarNS = "urn:xmlast:grammar";
+    private String tokenNS = "urn:xmlast:token";
     private final String grammar;
 
     private Class<Parser> parserClass;
@@ -135,7 +135,7 @@ public class XmlAstWriter {
         // parser.setBuildParseTree(false);
         // convert
         xmlStreamWriter.writeStartDocument("UTF-8", "1.0");
-        xmlStreamWriter.writeStartElement("sql");
+        xmlStreamWriter.writeStartElement("ast"); // document element
         xmlStreamWriter.writeDefaultNamespace(grammarNS);
         xmlStreamWriter.writeNamespace("c", commentNS);
         xmlStreamWriter.writeNamespace("t", tokenNS);
@@ -143,7 +143,7 @@ public class XmlAstWriter {
         xmlStreamWriter.writeAttribute("path", path.replaceAll("\\\\", "/"));
         xmlStreamWriter.writeAttribute("numlines", Integer.toString(countLines(inFile)));
         final ParseTreeWalker walker = new ParseTreeWalker();
-        walker.walk(writer, (ParseTree) (parserClass.getMethod("sql_script")).invoke(parser));
+        walker.walk(writer, (ParseTree) (parserClass.getMethod("script")).invoke(parser));
         flushKeepSpace();
         xmlStreamWriter.writeEndElement();
         xmlStreamWriter.writeEndDocument();

--- a/src/main/java/nl/xs4all/home/ei/parsers/antlr/XmlAstWriter.java
+++ b/src/main/java/nl/xs4all/home/ei/parsers/antlr/XmlAstWriter.java
@@ -235,6 +235,8 @@ public class XmlAstWriter {
 
     private void writeComment(final String comment, final String tagName) throws XMLStreamException {
 
+        // if there is any space pending get rid of it
+        flushKeepSpace();
 
         if (tagName.equals("SPACES")) {
             // defer output space until next open tag

--- a/src/main/stylesheets/sqlxmlast-json-stucture.xsl
+++ b/src/main/stylesheets/sqlxmlast-json-stucture.xsl
@@ -9,15 +9,15 @@ Jurgen Hildebrand (ei@xs4all.nl)
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0"
-                xmlns:g="urn:language:sql:grammar"
-                xmlns:c="urn:language:sql:comment"
-                xmlns:t="urn:language:sql:token"
+                xmlns:g="urn:xmlast:grammar"
+                xmlns:c="urn:xmlast:comment"
+                xmlns:t="urn:xmlast:token"
                 xmlns="http://www.w3.org/2005/xpath-functions"
                 exclude-result-prefixes="xs g c t">
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/>
     <!-- convert AST trees to JSON -->
-    <xsl:template match="g:sql" priority="1">
+    <xsl:template match="g:ast" priority="1">
         <map xmlns="http://www.w3.org/2005/xpath-functions">
             <map key="head">
                 <xsl:for-each select="@*">

--- a/src/main/stylesheets/sqlxmlast-short-html.xsl
+++ b/src/main/stylesheets/sqlxmlast-short-html.xsl
@@ -9,9 +9,9 @@ Jurgen Hildebrand (ei@xs4all.nl)
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0"
-                xmlns:g="urn:language:sql:grammar"
-                xmlns:c="urn:language:sql:comment"
-                xmlns:t="urn:language:sql:token"
+                xmlns:g="urn:xmlast:grammar"
+                xmlns:c="urn:xmlast:comment"
+                xmlns:t="urn:xmlast:token"
                 xmlns:fn="http://www.w3.org/2005/xpath-functions"
                 exclude-result-prefixes="xs g c t fn">
     <xsl:output method="html" indent="yes"/>

--- a/src/main/stylesheets/sqlxmlast-shorten.xsl
+++ b/src/main/stylesheets/sqlxmlast-shorten.xsl
@@ -102,6 +102,12 @@ Jurgen Hildebrand (ei@xs4all.nl)
                 <xsl:when test="ancestor::g:id_expression[1]/following-sibling::element()[1]/self::t:PERIOD">
                     <xsl:value-of select="'table_alias_ref'"/>
                 </xsl:when>
+                <xsl:when test="ancestor::g:identifier[1]/following-sibling::element()[1]/self::t:PERIOD">
+                    <xsl:value-of select="'table_alias_ref'"/>
+                </xsl:when>
+
+
+
                 <xsl:when test="ancestor::g:id_expression[1]/preceding-sibling::element()[1]/self::t:PERIOD">
                     <xsl:value-of select="'column_name'"/>
                 </xsl:when>

--- a/src/main/stylesheets/sqlxmlast-shorten.xsl
+++ b/src/main/stylesheets/sqlxmlast-shorten.xsl
@@ -17,9 +17,9 @@ Jurgen Hildebrand (ei@xs4all.nl)
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0"
-    xmlns:g="urn:language:sql:grammar" 
-    xmlns:c="urn:language:sql:comment"
-    xmlns:t="urn:language:sql:token"
+    xmlns:g="urn:xmlast:grammar"
+    xmlns:c="urn:xmlast:comment"
+    xmlns:t="urn:xmlast:token"
     xmlns="http://www.w3.org/2005/xpath-functions"
     exclude-result-prefixes="xs">
     <xsl:output method="xml" indent="yes"/>
@@ -27,12 +27,12 @@ Jurgen Hildebrand (ei@xs4all.nl)
 
     <xsl:template match="/">
         <xsl:variable name="label-tree" as="node()*">
-            <xsl:apply-templates select="@* | g:sql" mode="label-tree"/>
+            <xsl:apply-templates select="@* | g:ast" mode="label-tree"/>
         </xsl:variable>
         <xsl:apply-templates select="$label-tree" mode="shorten-single-element-nestings-copy"/>
     </xsl:template>
     <!-- root -->
-    <xsl:template match="g:sql" priority="1" mode="shorten-single-element-nestings-copy">
+    <xsl:template match="g:ast" priority="1" mode="shorten-single-element-nestings-copy">
         <xsl:copy>
             <xsl:apply-templates select="@* | node()" mode="shorten-single-element-nestings-copy"/>
         </xsl:copy>


### PR DESCRIPTION
* removed SQL from xml namespaces because it doesn't make sense when parsing non sql languages such as java, antlr
* changed element names to remove sql 
* fixes on whitespace handling 